### PR TITLE
✨ Add config for additional prompt instructions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -7,9 +7,13 @@ Check [defaults.go](../config/defaults.go) for mode details.
 The config file is stored in `$HOME/.config/gh-aipr/config.yaml`
 
 ```yaml
-# if you choose to override the prompt make sure to check the current one
-# in llm/prompt.go as yours going to replace the default one
+# Completely replaces the default system prompt
+# in llm/prompt.go with your custom prompt
 system_prompt_override: "You are a helpful assistant."
+
+# Extends the system prompt (or override) with additional instructions
+# These will be appended to the prompt with a clear section header
+additional_instructions: "Focus on security implications of the changes."
 
 # set the models to ones you want to use
 # you don't have to set all of them too

--- a/llm/prompt.go
+++ b/llm/prompt.go
@@ -56,10 +56,17 @@ func getUserPrompt(commits []string, diff string, prTemplate string) string {
 }
 
 func getSystemPrompt() string {
-	if prompt := viper.GetString("system_prompt_override"); prompt != "" {
-		return prompt
+	basePrompt := SYSTEM_PROMPT
+
+	if override := viper.GetString("system_prompt_override"); override != "" {
+		basePrompt = override
 	}
-	return SYSTEM_PROMPT
+
+	if instructions := viper.GetString("additional_instructions"); instructions != "" {
+		return basePrompt + "\n\n## Additional User-Customized Instructions\n" + instructions
+	}
+
+	return basePrompt
 }
 
 type Response struct {


### PR DESCRIPTION
# Motiviation

<!-- Describe the motivation behind this PR -->
Users may want to provide specific instructions to the AI model without completely overriding the default system prompt.

# Changes

<!-- Describe the changes made in this PR -->
* Added a new configuration option `additional_instructions`.
* Updated the prompt generation logic to append these instructions to the system prompt.
* Documented the new configuration option.

# Expected behavior

<!-- Describe the expected behavior of the changes made in this PR -->
When `additional_instructions` is configured, the generated AI prompt should include these instructions after the main system prompt.

📝🤖✨🛠️📦