### PR TITLE
⚙️ Add support for global and local config loading

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -1,14 +1,38 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/viper"
 )
 
 func LoadConfig() {
 	setDefaults()
 
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath("$HOME/.config/gh-aipr")
-	_ = viper.ReadInConfig()
+	globalViper := viper.New()
+	globalViper.SetConfigName("config")
+	globalViper.SetConfigType("yaml")
+	globalViper.AddConfigPath("$HOME/.config/gh-aipr")
+	_ = globalViper.ReadInConfig()
+
+	for _, key := range globalViper.AllKeys() {
+		viper.Set(key, globalViper.Get(key))
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	localConfigPath := filepath.Join(cwd, ".github", "gh-aipr", "config.yaml")
+	if _, err := os.Stat(localConfigPath); err == nil {
+		localViper := viper.New()
+		localViper.SetConfigFile(localConfigPath)
+		if err := localViper.ReadInConfig(); err == nil {
+			for _, key := range localViper.AllKeys() {
+				viper.Set(key, localViper.Get(key))
+			}
+		}
+	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,7 +4,9 @@ There're some sensible defaults configured for the tool.
 
 Check [defaults.go](../config/defaults.go) for mode details.
 
-The config file is stored in `$HOME/.config/gh-aipr/config.yaml`
+## Global Configuration
+
+The global config file is stored in `$HOME/.config/gh-aipr/config.yaml`
 
 ```yaml
 # if you choose to override the prompt make sure to check the current one
@@ -22,3 +24,13 @@ anthropic:
 gemini:
     model_name: "gemini-2.5-flash-preview-04-17"
 ```
+
+## Local Repository Configuration
+
+You can also create a local configuration file within a git repository that will be merged with the global configuration. 
+
+Local configuration should be placed at `.github/gh-aipr/config.yaml` in your repository.
+
+This might be useful if you want to specify model or instructions on a per-repository basis.
+
+The local configuration will override the global configuration for identical keys, and both configurations will be deep merged.


### PR DESCRIPTION
# Motiviation

<!-- Describe the motivation behind this PR -->
Allows users to set global configurations for the tool and provide repository-specific overrides.

# Changes

<!-- Describe the changes made in this PR -->
*   Updated config loading to read from `$HOME/.config/gh-aipr/config.yaml`.
*   Added support for reading local config from `.github/gh-aipr/config.yaml`.
*   Implemented logic to merge global and local configs, with local settings taking precedence.
*   Updated documentation to reflect the new configuration options.

# Expected behavior

<!-- Describe the expected behavior of the changes made in this PR -->
The tool should now load configuration from both the global path and the local repository path, applying local settings over global ones when they conflict.