### PR TITLE
⚙️ Add config option to force LLM provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build/Test Commands
+- Build: `go build`
+- Run: `go run .` 
+- Test: `go test ./...`
+- Test specific file: `go test ./path/to/package`
+- Test specific function: `go test -run TestFunctionName ./path/to/package`
+
+## Code Style Guidelines
+- **Formatting**: Use `gofmt` or `go fmt ./...` to format code
+- **Imports**: Group stdlib first, then third-party packages with a blank line between
+- **Error handling**: Use direct `if err != nil` checks, return errors with context
+- **Naming**: Use camelCase for variables, PascalCase for exported functions/types
+- **Comments**: Document exported functions with complete sentences
+- **PR conventions**: PR titles should be emojified and descriptive
+
+## Project Structure
+- `config/`: Configuration loading and defaults
+- `git/`: Git operations and command interfaces
+- `llm/`: LLM provider implementations (OpenAI, Anthropic, Gemini)
+- `utils/`: Utility functions and helpers

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -3,6 +3,7 @@ package config
 import "github.com/spf13/viper"
 
 func setDefaults() {
+	viper.SetDefault("provider", "")
 	viper.SetDefault("anthropic.model_name", "claude-3-5-haiku-latest")
 	viper.SetDefault("gemini.model_name", "gemini-2.5-flash-preview-04-17")
 	viper.SetDefault("openai.model_name", "gpt-4o-mini")

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,11 @@ Check [defaults.go](../config/defaults.go) for mode details.
 The config file is stored in `$HOME/.config/gh-aipr/config.yaml`
 
 ```yaml
+# Force use of a specific provider (optional)
+# Valid values: "openai", "anthropic", "gemini"
+# If not set, the tool will auto-detect based on available API keys
+provider: "anthropic"
+
 # if you choose to override the prompt make sure to check the current one
 # in llm/prompt.go as yours going to replace the default one
 system_prompt_override: "You are a helpful assistant."
@@ -22,3 +27,15 @@ anthropic:
 gemini:
     model_name: "gemini-2.5-flash-preview-04-17"
 ```
+
+## Provider Selection
+
+The tool supports three LLM providers: OpenAI, Anthropic, and Gemini. By default, it will automatically select a provider based on which API keys are available in your environment variables.
+
+If you want to force the use of a specific provider, you can set the `provider` configuration option to one of: `"openai"`, `"anthropic"`, or `"gemini"`. When a specific provider is configured, the tool will:
+
+1. Only attempt to use that provider
+2. Show an error if the required API key for that provider is not set
+3. Not fall back to other providers
+
+For example, if you set `provider: "anthropic"` but don't have the `ANTHROPIC_API_KEY` environment variable set, the tool will display an error message and exit.

--- a/llm/prompt.go
+++ b/llm/prompt.go
@@ -68,36 +68,35 @@ type Response struct {
 }
 
 func getProvider(ctx context.Context) LLMProvider {
-	// Define provider configurations
-	providerConfigs := map[string]struct {
-		envKey string
-		initFn func(string, context.Context) LLMProvider
-	}{
-		"gemini": {
-			envKey: "GEMINI_API_KEY",
-			initFn: func(key string, ctx context.Context) LLMProvider {
-				return NewGeminiProvider(key, ctx)
-			},
+	providerCreators := map[string]func(context.Context) LLMProvider{
+		"gemini": func(ctx context.Context) LLMProvider {
+			key := os.Getenv("GEMINI_API_KEY")
+			if key == "" {
+				return nil
+			}
+			return NewGeminiProvider(key, ctx)
 		},
-		"openai": {
-			envKey: "OPENAI_API_KEY",
-			initFn: func(key string, ctx context.Context) LLMProvider {
-				return NewOpenaiProvider(key)
-			},
+		"openai": func(ctx context.Context) LLMProvider {
+			key := os.Getenv("OPENAI_API_KEY")
+			if key == "" {
+				return nil
+			}
+			return NewOpenaiProvider(key)
 		},
-		"anthropic": {
-			envKey: "ANTHROPIC_API_KEY",
-			initFn: func(key string, ctx context.Context) LLMProvider {
-				return NewAnthropicProvider(key)
-			},
+		"anthropic": func(ctx context.Context) LLMProvider {
+			key := os.Getenv("ANTHROPIC_API_KEY")
+			if key == "" {
+				return nil
+			}
+			return NewAnthropicProvider(key)
 		},
 	}
 
 	configuredProvider := viper.GetString("provider")
-	
+
 	providersToTry := []string{"gemini", "openai", "anthropic"}
 	if configuredProvider != "" {
-		if _, exists := providerConfigs[configuredProvider]; !exists {
+		if _, exists := providerCreators[configuredProvider]; !exists {
 			fmt.Fprintf(os.Stderr, "Error: Unknown provider '%s' specified in config\n", configuredProvider)
 			return nil
 		}
@@ -105,20 +104,17 @@ func getProvider(ctx context.Context) LLMProvider {
 	}
 
 	for _, providerName := range providersToTry {
-		config := providerConfigs[providerName]
-		if key := os.Getenv(config.envKey); key != "" {
-			if provider := config.initFn(key, ctx); provider != nil {
-				return provider
-			}
+		createFn := providerCreators[providerName]
+		if provider := createFn(ctx); provider != nil {
+			return provider
 		} else if configuredProvider != "" {
-			fmt.Fprintf(os.Stderr, "Error: Provider '%s' specified in config but %s is not set\n", 
-				providerName, config.envKey)
+			fmt.Fprintf(os.Stderr, "Error: Provider '%s' specified in config but required API key is not set\n", providerName)
 			return nil
 		}
 	}
 
 	if configuredProvider == "" {
-		fmt.Fprintf(os.Stderr, "Error: No API keys found for any supported provider (OpenAI, Anthropic, Gemini)\n")
+		fmt.Fprintf(os.Stderr, "Error: No API keys found for any supported provider\n")
 	}
 	return nil
 }

--- a/llm/prompt.go
+++ b/llm/prompt.go
@@ -68,27 +68,58 @@ type Response struct {
 }
 
 func getProvider(ctx context.Context) LLMProvider {
-	if key := os.Getenv("GEMINI_API_KEY"); key != "" {
-		provider := NewGeminiProvider(key, ctx)
-		if provider != nil {
-			return provider
+	// Define provider configurations
+	providerConfigs := map[string]struct {
+		envKey string
+		initFn func(string, context.Context) LLMProvider
+	}{
+		"gemini": {
+			envKey: "GEMINI_API_KEY",
+			initFn: func(key string, ctx context.Context) LLMProvider {
+				return NewGeminiProvider(key, ctx)
+			},
+		},
+		"openai": {
+			envKey: "OPENAI_API_KEY",
+			initFn: func(key string, ctx context.Context) LLMProvider {
+				return NewOpenaiProvider(key)
+			},
+		},
+		"anthropic": {
+			envKey: "ANTHROPIC_API_KEY",
+			initFn: func(key string, ctx context.Context) LLMProvider {
+				return NewAnthropicProvider(key)
+			},
+		},
+	}
+
+	configuredProvider := viper.GetString("provider")
+	
+	providersToTry := []string{"gemini", "openai", "anthropic"}
+	if configuredProvider != "" {
+		if _, exists := providerConfigs[configuredProvider]; !exists {
+			fmt.Fprintf(os.Stderr, "Error: Unknown provider '%s' specified in config\n", configuredProvider)
+			return nil
+		}
+		providersToTry = []string{configuredProvider}
+	}
+
+	for _, providerName := range providersToTry {
+		config := providerConfigs[providerName]
+		if key := os.Getenv(config.envKey); key != "" {
+			if provider := config.initFn(key, ctx); provider != nil {
+				return provider
+			}
+		} else if configuredProvider != "" {
+			fmt.Fprintf(os.Stderr, "Error: Provider '%s' specified in config but %s is not set\n", 
+				providerName, config.envKey)
+			return nil
 		}
 	}
 
-	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
-		provider := NewOpenaiProvider(key)
-		if provider != nil {
-			return provider
-		}
+	if configuredProvider == "" {
+		fmt.Fprintf(os.Stderr, "Error: No API keys found for any supported provider (OpenAI, Anthropic, Gemini)\n")
 	}
-
-	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
-		provider := NewAnthropicProvider(key)
-		if provider != nil {
-			return provider
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Motivation

<!-- Describe the motivation behind this PR -->
This change allows users to explicitly configure and force the use of a specific LLM provider instead of relying solely on auto-detection based on available API keys.

# Changes

<!-- Describe the changes made in this PR -->
*   Added a `provider` configuration option to force a specific LLM provider.
*   Refactored provider selection logic to support the forced provider and improve error handling.
*   Updated documentation (`docs/config.md`) and default configuration.
*   Added a new `CLAUDE.md` file with guidance for AI models.

# Expected behavior

<!-- Describe the expected behavior of the changes made in this PR -->
Users can now specify a preferred provider in the configuration. If a provider is specified, the tool will attempt to use only that provider and indicate if the required API key is missing. If no provider is specified, the tool continues to auto-detect.