### PR TITLE
Add animated loader during PR description generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,11 @@ require (
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
 	github.com/google/generative-ai-go v0.19.0
 	github.com/invopop/jsonschema v0.13.0
-	github.com/openai/openai-go v0.1.0-beta.10
-	github.com/spf13/viper v1.20.1
+       github.com/openai/openai-go v0.1.0-beta.10
+       github.com/charmbracelet/bubbletea v0.25.0
+       github.com/charmbracelet/bubbles v0.15.0
+       github.com/charmbracelet/lipgloss v0.9.0
+       github.com/spf13/viper v1.20.1
 	google.golang.org/api v0.228.0
 )
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,10 @@ import (
 )
 
 func getTitleAndBody(commits []string, diff string, template string, ctx context.Context) (*string, *string) {
+	stop := utils.StartLoader("Generating description...")
 	title, body := llm.GenerateTitleAndBody(commits, diff, template, ctx)
+	stop()
+	fmt.Println()
 
 	if title == nil {
 		if defaultTitle := git.GenerateTitle(commits); defaultTitle != nil {

--- a/utils/loader.go
+++ b/utils/loader.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type loaderModel struct {
+	spinner spinner.Model
+	text    string
+}
+
+func newLoaderModel(text string) loaderModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	return loaderModel{spinner: s, text: text}
+}
+
+func (m loaderModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+type doneMsg struct{}
+
+func (m loaderModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	case doneMsg:
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m loaderModel) View() string {
+	return fmt.Sprintf("%s %s", m.spinner.View(), m.text)
+}
+
+// StartLoader runs the spinner asynchronously and returns a function to stop it.
+func StartLoader(text string) func() {
+	program := tea.NewProgram(newLoaderModel(text))
+	go func() {
+		// ignore errors so loader doesn't block main flow
+		_, _ = program.Run()
+	}()
+	return func() { _ = program.Quit() }
+}


### PR DESCRIPTION
## Summary
- add new utility to display Charm spinner
- show spinner in main while description is generated
- require charmbracelet modules

## Testing
- `gofmt -w utils/loader.go main.go`


------
https://chatgpt.com/codex/tasks/task_e_686238362934832f82726cbe8f0f9e80